### PR TITLE
Frontend/add axios support

### DIFF
--- a/frontend/config/index.js
+++ b/frontend/config/index.js
@@ -10,7 +10,13 @@ module.exports = {
     // Paths
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
-    proxyTable: {},
+    proxyTable: {
+      // proxy all webpack dev-server requests starting with /api to our Spring Boot backend (localhost:8088)
+      '/api': {
+        target: 'http://localhost:8088',
+        changeOrigin: true
+      }
+    },
 
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "peer": "^0.2.10",
+    "axios": "^0.18.0",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1"
   },

--- a/frontend/src/components/http-common.js
+++ b/frontend/src/components/http-common.js
@@ -1,0 +1,5 @@
+import axios from 'axios'
+
+export const AXIOS = axios.create({
+  baseURL: '/api'
+})


### PR DESCRIPTION
Create all witch need to use axios. 
To import axios into component need import axios from core folder "components":
`import {AXIOS} from 'http-common'`

Get-request example:

```
AXIOS.get('/admin/getFormats')
      .then(response => {
        // To use responces data use response.data
        // Do smth cool
      }).catch(e => {
        console.log(e)
      })
```